### PR TITLE
Fixes for problems in stormpy tests

### DIFF
--- a/src/storm-pomdp/api/verification.h
+++ b/src/storm-pomdp/api/verification.h
@@ -4,13 +4,14 @@ namespace pomdp {
 namespace api {
 
     template<typename ValueType>
-    typename storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<ValueType>::Result
+    typename storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>>::Result
     underapproximateWithCutoffs(storm::Environment const& env, std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> pomdp,
                               storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& task, uint64_t sizeThreshold,  std::vector<std::vector<ValueType>> pomdpStateValues = std::vector<std::vector<ValueType>>()){
         storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType> options(false,true);
+        options.useGridClipping = false;
         options.useExplicitCutoff = true;
         options.sizeThresholdInit = sizeThreshold;
-        storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<ValueType> modelchecker(pomdp, options);
+        storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>> modelchecker(pomdp, options);
         return modelchecker.check(task.getFormula(), pomdpStateValues);
     }
 

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -352,7 +352,11 @@ namespace storm {
                         auto inducedMC = newMDP.applyScheduler(*(approx->getSchedulerForExploredMdp()), true);
                         scheduledModel = std::static_pointer_cast<storm::models::sparse::Model<ValueType>>(inducedMC);
                         result.schedulerAsMarkovChain = scheduledModel;
-                        result.cutoffSchedulers = approx->getLowerValueBoundSchedulers();
+                        if(min){
+                            result.cutoffSchedulers = approx->getUpperValueBoundSchedulers();
+                        } else {
+                            result.cutoffSchedulers = approx->getLowerValueBoundSchedulers();
+                        }
                         ValueType &resultValue = min ? result.upperBound : result.lowerBound;
                         resultValue = approx->getComputedValueAtInitialState();
                     }

--- a/src/test/storm-pomdp/CMakeLists.txt
+++ b/src/test/storm-pomdp/CMakeLists.txt
@@ -9,7 +9,7 @@ register_source_groups_from_filestructure("${ALL_FILES}" test)
 # Note that the tests also need the source files, except for the main file
 include_directories(${GTEST_INCLUDE_DIR})
 
-foreach (testsuite analysis transformation modelchecker tracking)
+foreach (testsuite analysis transformation modelchecker tracking api)
 
 	  file(GLOB_RECURSE TEST_${testsuite}_FILES ${STORM_TESTS_BASE_PATH}/${testsuite}/*.h ${STORM_TESTS_BASE_PATH}/${testsuite}/*.cpp)
       add_executable (test-pomdp-${testsuite} ${TEST_${testsuite}_FILES} ${STORM_TESTS_BASE_PATH}/storm-test.cpp)

--- a/src/test/storm-pomdp/api/BeliefExplorationAPITest.cpp
+++ b/src/test/storm-pomdp/api/BeliefExplorationAPITest.cpp
@@ -1,0 +1,209 @@
+#include "storm-config.h"
+#include "test/storm_gtest.h"
+
+#include "storm-parsers/api/storm-parsers.h"
+#include "storm-pomdp/analysis/QualitativeAnalysisOnGraphs.h"
+#include "storm-pomdp/api/verification.h"
+#include "storm-pomdp/transformer/GlobalPOMDPSelfLoopEliminator.h"
+#include "storm-pomdp/transformer/KnownProbabilityTransformer.h"
+#include "storm-pomdp/transformer/MakePOMDPCanonic.h"
+#include "storm/api/storm.h"
+
+#include "storm/environment/solver/MinMaxSolverEnvironment.h"
+
+class DefaultDoubleVIEnvironment {
+   public:
+    typedef double ValueType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::ValueIteration);
+        env.solver().minMax().setPrecision(storm::utility::convertNumber<storm::RationalNumber>(1e-6));
+        return env;
+    }
+    static bool const isExactModelChecking = false;
+    static ValueType precision() {
+        return storm::utility::convertNumber<ValueType>(0.12);
+    }  // there actually aren't any precision guarantees, but we still want to detect if results are weird.
+    static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>&) { /* intentionally left empty */
+    }
+};
+
+template<typename TestType>
+class BeliefExplorationAPITest : public ::testing::Test {
+   public:
+    typedef typename TestType::ValueType ValueType;
+    BeliefExplorationAPITest() : _environment(TestType::createEnvironment()) {}
+    storm::Environment const& env() const {
+        return _environment;
+    }
+
+    ValueType parseNumber(std::string const& str) {
+        return storm::utility::convertNumber<ValueType>(str);
+    }
+    struct Input {
+        std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> model;
+        std::shared_ptr<storm::logic::Formula const> formula;
+    };
+    Input buildPrism(std::string const& programFile, std::string const& formulaAsString, std::string const& constantsAsString = "") const {
+        // Parse and build input
+        storm::prism::Program program = storm::api::parseProgram(programFile);
+        program = storm::utility::prism::preprocess(program, constantsAsString);
+        Input input;
+        input.formula = storm::api::parsePropertiesForPrismProgram(formulaAsString, program).front().getRawFormula();
+        input.model = storm::api::buildSparseModel<ValueType>(program, {input.formula})->template as<storm::models::sparse::Pomdp<ValueType>>();
+
+        // Preprocess
+        storm::transformer::MakePOMDPCanonic<ValueType> makeCanonic(*input.model);
+        input.model = makeCanonic.transform();
+        EXPECT_TRUE(input.model->isCanonic());
+        return input;
+    }
+    ValueType precision() const {
+        return TestType::precision();
+    }
+    ValueType modelcheckingPrecision() const {
+        if (TestType::isExactModelChecking)
+            return storm::utility::zero<ValueType>();
+        else
+            return storm::utility::convertNumber<ValueType>(1e-6);
+    }
+
+   private:
+    storm::Environment _environment;
+};
+
+typedef ::testing::Types<DefaultDoubleVIEnvironment> TestingTypes;
+
+TYPED_TEST_SUITE(BeliefExplorationAPITest, TestingTypes, );
+
+TYPED_TEST(BeliefExplorationAPITest, simple_Pmax) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("7/10");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, simple_Pmin) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmin=? [F \"goal\" ]", "slippery=0");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("3/10");
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Pmax) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmax=? [F \"goal\" ]", "slippery=0.4");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("7/10");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Pmin) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Pmin=? [F \"goal\" ]", "slippery=0.4");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("3/10");
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, simple_Rmax) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("29/50");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, simple_Rmin) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("19/50");
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmax) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmax=? [F s>4 ]", "slippery=0.4");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("29/30");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmin) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/simple.prism", "Rmin=? [F s>4 ]", "slippery=0.4");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("19/30");
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, maze2_Rmin) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]min=? [F \"goal\"]", "sl=0");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("74/91");
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, maze2_slippery_Rmin) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/maze2.prism", "R[exp]min=? [F \"goal\"]", "sl=0.075");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("80/91");
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, refuel_Pmax) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/refuel.prism", "Pmax=?[\"notbad\" U \"goal\"]", "N=4");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("38/155");
+    EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
+}
+
+TYPED_TEST(BeliefExplorationAPITest, refuel_Pmin) {
+    typedef typename TestFixture::ValueType ValueType;
+
+    auto data = this->buildPrism(STORM_TEST_RESOURCES_DIR "/pomdp/refuel.prism", "Pmin=?[\"notbad\" U \"goal\"]", "N=4");
+    auto task = storm::api::createTask<ValueType>(data.formula, false);
+    auto result = storm::pomdp::api::underapproximateWithCutoffs<ValueType>(this->env(), data.model, task, 100);
+
+    ValueType expected = this->parseNumber("0");
+    EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
+}


### PR DESCRIPTION
This PR contains fixes for the bugs that previously caused the POMDP cutoff tests of the stormpy fork to fail.

In particular, the fixes are:
- The missing handling of reach-avoid formulae in the belief exploration model checker. The states to avoid are now made absorbing, leading to the property reducing to a simple reachability query.
- An error where cutoff schedulers for minimisation properties were not stored correctly.