### PR TITLE
Fix for incorrect labels and empty choices in preprocessing

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -448,6 +448,7 @@ std::shared_ptr<storm::models::ModelBase> buildModelSparse(SymbolicInput const& 
     options.setBuildChoiceLabels(options.isBuildChoiceLabelsSet() || buildSettings.isBuildChoiceLabelsSet());
     options.setBuildStateValuations(options.isBuildStateValuationsSet() || buildSettings.isBuildStateValuationsSet());
     options.setBuildAllLabels(options.isBuildAllLabelsSet() || buildSettings.isBuildAllLabelsSet());
+    options.setBuildObservationValuations(options.isBuildObservationValuationsSet() || buildSettings.isBuildObservationValuationsSet());
     bool buildChoiceOrigins = options.isBuildChoiceOriginsSet() || buildSettings.isBuildChoiceOriginsSet();
     if (storm::settings::manager().hasModule(storm::settings::modules::CounterexampleGeneratorSettings::moduleName)) {
         auto counterexampleGeneratorSettings = storm::settings::getModule<storm::settings::modules::CounterexampleGeneratorSettings>();

--- a/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
+++ b/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
@@ -522,6 +522,24 @@ namespace storm {
             clippedStates.resize(getCurrentNumberOfMdpStates(), false);
             mdpLabeling.addLabel("clipped", std::move(clippedStates));
 
+            for(uint64_t state = 0; state < getCurrentNumberOfMdpStates(); ++state){
+                if(state == extraBottomState || state == extraTargetState){
+                    if(!mdpLabeling.containsLabel("__extra")) {
+                        mdpLabeling.addLabel("__extra");
+                    }
+                    mdpLabeling.addLabelToState("__extra", state);
+                } else {
+                    STORM_LOG_DEBUG("Observation of MDP state " << state << " : " << beliefManager->getObservationLabel(mdpStateToBeliefIdMap[state]) << "\n");
+                    std::string obsLabel = beliefManager->getObservationLabel(mdpStateToBeliefIdMap[state]);
+                    if (!obsLabel.empty()) {
+                        if (!mdpLabeling.containsLabel(obsLabel)) {
+                            mdpLabeling.addLabel(obsLabel);
+                        }
+                        mdpLabeling.addLabelToState(obsLabel, state);
+                    }
+                }
+            }
+
             // Create a standard reward model (if rewards are available)
             std::unordered_map<std::string, storm::models::sparse::StandardRewardModel<ValueType>> mdpRewardModels;
             if (!mdpActionRewards.empty()) {

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -150,6 +150,9 @@ namespace storm {
                             if(pomdp().hasChoiceLabeling()){
                                 components.choiceLabeling = pomdp().getChoiceLabeling();
                             }
+                            if(pomdp().hasObservationValuations()){
+                                components.observationValuations = pomdp().getObservationValuations();
+                            }
                             preprocessedPomdp = std::make_shared<storm::models::sparse::Pomdp<ValueType>>(std::move(components), true);
                             auto reachableFromSinkStates = storm::utility::graph::getReachableStates(pomdp().getTransitionMatrix(), formulaInfo.getSinkStates().states, formulaInfo.getSinkStates().states, ~formulaInfo.getSinkStates().states);
                             reachableFromSinkStates &= ~formulaInfo.getSinkStates().states;
@@ -610,7 +613,7 @@ namespace storm {
                 statistics.overApproximationBuildTime.start();
                 storm::storage::BitVector refinedObservations;
                 if (!refine) {
-                    // If we build the model from scratch, we first have to setup the explorer for the overApproximation.
+                    // If we build the model from scratch, we first have to set up the explorer for the overApproximation.
                     if (computeRewards) {
                         overApproximation->startNewExploration(storm::utility::zero<ValueType>());
                     } else {

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -951,8 +951,9 @@ namespace storm {
                                 // Always restore old behavior if available
                                 if(pomdp().hasChoiceLabeling()){
                                     if(pomdp().getChoiceLabeling().getLabelsOfChoice(beliefManager->getRepresentativeState(currId)+action).size() > 0) {
+                                        auto rowIndex = pomdp().getTransitionMatrix().getRowGroupIndices()[beliefManager->getRepresentativeState(currId)];
                                         underApproximation->addChoiceLabelToCurrentState(
-                                            addedActions + action,*(pomdp().getChoiceLabeling().getLabelsOfChoice(beliefManager->getRepresentativeState(currId)+action).begin()));
+                                            addedActions + action,*(pomdp().getChoiceLabeling().getLabelsOfChoice(rowIndex+action).begin()));
                                     }
                                 }
                                 if (stateAlreadyExplored) {

--- a/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.cpp
@@ -371,11 +371,11 @@ namespace storm {
             template
             class PreprocessingPomdpValueBoundsModelChecker<storm::RationalNumber>;
 
-            template class PreprocessingPomdpValueBounds<double>;
-            template class PreprocessingPomdpValueBounds<storm::RationalNumber>;
+            template struct PreprocessingPomdpValueBounds<double>;
+            template struct PreprocessingPomdpValueBounds<storm::RationalNumber>;
 
-            template class ExtremePOMDPValueBound<double>;
-            template class ExtremePOMDPValueBound<storm::RationalNumber>;
+            template struct ExtremePOMDPValueBound<double>;
+            template struct ExtremePOMDPValueBound<storm::RationalNumber>;
         }
     }
 }

--- a/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.cpp
@@ -117,6 +117,12 @@ namespace storm {
                         }
 
                     }
+                    // If the distribution is empty, i.e. no choice has had a suitable score, distribute uniformly
+                    if(choiceDistribution.size() == 0){
+                        for (auto choice = choiceIndices[state]; choice < choiceIndices[state + 1]; ++choice) {
+                            choiceDistribution.addProbability(choice - choiceIndices[state], scoreThreshold);
+                        }
+                    }
                     STORM_LOG_ASSERT(choiceDistribution.size() > 0, "Empty choice distribution.");
                 }
                 // Normalize all distributions

--- a/src/storm-pomdp/storage/BeliefManager.cpp
+++ b/src/storm-pomdp/storage/BeliefManager.cpp
@@ -951,6 +951,17 @@ namespace storm {
             return getBelief(beliefId).begin()->first;
         }
 
+        template<typename PomdpType, typename BeliefValueType, typename StateType>
+        std::string BeliefManager<PomdpType, BeliefValueType, StateType>::getObservationLabel(BeliefId const &beliefId) {
+            if(pomdp.hasObservationValuations()){
+                return pomdp.getObservationValuations().getStateInfo(getBeliefObservation(beliefId));
+            } else {
+                STORM_LOG_WARN("Cannot get observation labels as no observation valuation has been defined for the POMDP. Return empty label instead.");
+                return "";
+            }
+
+        }
+
         template class BeliefManager<storm::models::sparse::Pomdp<double>>;
 
         template class BeliefManager<storm::models::sparse::Pomdp<double>, storm::RationalNumber>;

--- a/src/storm-pomdp/storage/BeliefManager.h
+++ b/src/storm-pomdp/storage/BeliefManager.h
@@ -98,6 +98,8 @@ namespace storm {
 
             BeliefClipping clipBeliefToGrid(BeliefId const &beliefId, uint64_t resolution, storm::storage::BitVector isInfinite);
 
+            std::string getObservationLabel(BeliefId const & beliefId);
+
         private:
 
             BeliefClipping clipBeliefToGrid(BeliefType const &belief, uint64_t resolution, const storm::storage::BitVector& isInfinite);

--- a/src/storm/builder/BuilderOptions.cpp
+++ b/src/storm/builder/BuilderOptions.cpp
@@ -44,6 +44,7 @@ BuilderOptions::BuilderOptions(bool buildAllRewardModels, bool buildAllLabels)
       applyMaximalProgressAssumption(false),
       buildChoiceLabels(false),
       buildStateValuations(false),
+      buildObservationValuations(false),
       buildChoiceOrigins(false),
       scaleAndLiftTransitionRewards(true),
       explorationChecks(false),

--- a/src/storm/settings/modules/BuildSettings.cpp
+++ b/src/storm/settings/modules/BuildSettings.cpp
@@ -32,6 +32,7 @@ const std::string applyNoMaxProgAssumptionOptionName = "nomaxprog";
 const std::string buildChoiceLabelOptionName = "buildchoicelab";
 const std::string buildChoiceOriginsOptionName = "buildchoiceorig";
 const std::string buildStateValuationsOptionName = "buildstateval";
+const std::string buildObservationValuationsOptionName = "buildobsval";
 const std::string buildAllLabelsOptionName = "build-all-labels";
 const std::string buildOutOfBoundsStateOptionName = "build-out-of-bounds-state";
 const std::string buildOverlappingGuardsLabelOptionName = "build-overlapping-guards-label";
@@ -63,6 +64,7 @@ BuildSettings::BuildSettings() : ModuleSettings(moduleName) {
             .build());
     this->addOption(
         storm::settings::OptionBuilder(moduleName, buildStateValuationsOptionName, false, "If set, also build the state valuations").setIsAdvanced().build());
+    this->addOption(storm::settings::OptionBuilder(moduleName, buildObservationValuationsOptionName, false, "If set, also build the observation valuations (only relevant for POMDPs)").setIsAdvanced().build());
     this->addOption(storm::settings::OptionBuilder(moduleName, buildAllLabelsOptionName, false, "If set, build all labels").setIsAdvanced().build());
     this->addOption(storm::settings::OptionBuilder(moduleName, noBuildOptionName, false, "If set, do not build the model.").setIsAdvanced().build());
 
@@ -150,6 +152,10 @@ bool BuildSettings::isBuildChoiceOriginsSet() const {
 
 bool BuildSettings::isBuildStateValuationsSet() const {
     return this->getOption(buildStateValuationsOptionName).getHasOptionBeenSet();
+}
+
+bool BuildSettings::isBuildObservationValuationsSet() const {
+    return this->getOption(buildObservationValuationsOptionName).getHasOptionBeenSet();
 }
 
 bool BuildSettings::isBuildOutOfBoundsStateSet() const {

--- a/src/storm/settings/modules/BuildSettings.h
+++ b/src/storm/settings/modules/BuildSettings.h
@@ -92,6 +92,12 @@ class BuildSettings : public ModuleSettings {
     bool isBuildStateValuationsSet() const;
 
     /*!
+     * Retrieves whether the observation valuations should be build. Only relevant for POMDPs
+     * @return
+     */
+    bool isBuildObservationValuationsSet() const;
+
+    /*!
      * Retrieves whether out of bounds state should be added
      * @return
      */


### PR DESCRIPTION
The PR fixes a mismatch in IDs that lead to incorrect labels being displayed for choices in the belief MDP (and thus the induced MC).

Furthermore includes a fix for the problem leading to the maze example failing due to no choice being selected in the preprocessing.