### PR TITLE
Adding clipping support for POMDP policy export

### DIFF
--- a/src/storm-pomdp-cli/settings/modules/BeliefExplorationSettings.h
+++ b/src/storm-pomdp-cli/settings/modules/BeliefExplorationSettings.h
@@ -92,6 +92,8 @@ namespace storm {
                 bool isExplicitCutoffSet() const;
 
                 storm::builder::ExplorationHeuristic getExplorationHeuristic() const;
+
+                storm::solver::MinMaxMethod getPreProcMinMaxMethod() const;
     
                 template<typename ValueType>
                 void setValuesInOptionsStruct(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>& options) const;

--- a/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
+++ b/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
@@ -998,6 +998,16 @@ namespace storm {
         }
 
         template<typename PomdpType, typename BeliefValueType>
+        void BeliefMdpExplorer<PomdpType, BeliefValueType>::markAsGridBelief(BeliefId const &beliefId){
+            gridBeliefs.insert(beliefId);
+        }
+
+        template<typename PomdpType, typename BeliefValueType>
+        bool BeliefMdpExplorer<PomdpType, BeliefValueType>::isMarkedAsGridBelief(BeliefId const &beliefId){
+            return gridBeliefs.count(beliefId) > 0;
+        }
+
+        template<typename PomdpType, typename BeliefValueType>
         typename BeliefMdpExplorer<PomdpType, BeliefValueType>::MdpStateType BeliefMdpExplorer<PomdpType, BeliefValueType>::getExploredMdpState(BeliefId const &beliefId) const {
             if (beliefId < exploredBeliefIds.size() && exploredBeliefIds.get(beliefId)) {
                 return beliefIdToMdpStateMap.at(beliefId);

--- a/src/storm-pomdp/builder/BeliefMdpExplorer.h
+++ b/src/storm-pomdp/builder/BeliefMdpExplorer.h
@@ -234,6 +234,10 @@ namespace storm {
 
             uint64_t getNrSchedulersForLowerBounds();
 
+            void markAsGridBelief(BeliefId const &beliefId);
+
+            bool isMarkedAsGridBelief(BeliefId const &beliefId);
+
             const std::shared_ptr<storm::storage::Scheduler<BeliefMdpExplorer<PomdpType, BeliefValueType>::ValueType>> &getSchedulerForExploredMdp() const;
 
         private:
@@ -283,6 +287,7 @@ namespace storm {
             storm::storage::BitVector clippedStates;
             MdpStateType initialMdpState;
             storm::storage::BitVector delayedExplorationChoices;
+            std::unordered_set<BeliefId> gridBeliefs;
 
             // Final Mdp
             std::shared_ptr<storm::models::sparse::Mdp<ValueType>> exploredMdp;

--- a/src/storm-pomdp/io/PomdpToJuliaExport.cpp
+++ b/src/storm-pomdp/io/PomdpToJuliaExport.cpp
@@ -1,0 +1,280 @@
+#include "PomdpToJuliaExport.h"
+#include "storm-pomdp/analysis/FormulaInformation.h"
+#include "storm/exceptions/NotImplementedException.h"
+
+namespace storm {
+namespace pomdp {
+namespace exporter {
+
+template<typename ValueType>
+void exportPomdpToJulia(std::ostream& os, std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> pomdp, double discount, storm::logic::Formula const& formula){
+    os << std::setprecision(9);
+    STORM_LOG_ERROR_COND(pomdp->hasObservationValuations(), "POMDP was built without observation valuations. Export to Julia format not possible!");
+    STORM_LOG_ERROR_COND(pomdp->hasChoiceLabeling(), "POMDP was built without choice labeling. Export to Julia format not possible!");
+
+    // Analyse formula
+    auto formulaInfo = storm::pomdp::analysis::getFormulaInformation(*pomdp, formula);
+    bool probabilityAnalysis = !formula.isRewardOperatorFormula();
+    bool min = formulaInfo.minimize();
+    auto targetStates = formulaInfo.getTargetStates().states;
+
+    std::unordered_set<uint64_t> states;
+    std::unordered_set<std::string> observations;
+    std::set<std::string> actions;
+
+    std::unordered_map<uint64_t, std::vector<std::string>> stateActionMap;
+
+    std::vector<std::unordered_map<uint64_t, ValueType>> choices;
+
+    for (uint64_t state = 0; state < pomdp->getNumberOfStates(); ++state) {
+        auto rowIndex = pomdp->getTransitionMatrix().getRowGroupIndices()[state];
+        for (uint64_t action = 0; action < pomdp->getNumberOfChoices(state); ++action){
+            auto choiceLabeling = pomdp->getChoiceLabeling();
+            auto labelsOfChoice = choiceLabeling.getLabelsOfChoice(rowIndex+action);
+            if(labelsOfChoice.empty()){
+                actions.insert("__sink");
+                stateActionMap[state].push_back("__sink");
+            } else {
+                std::string label = *(labelsOfChoice.begin());
+                std::replace( label.begin(), label.end(), '\t', ' ');
+                std::replace( label.begin(), label.end(), '\n', ' ');
+                actions.insert(label);
+                stateActionMap[state].push_back(label);
+            }
+
+            std::unordered_map<uint64_t, ValueType> stateProbs;
+            for (auto const &pomdpTransition : pomdp->getTransitionMatrix().getRow(state, action)) {
+                if (!storm::utility::isZero(pomdpTransition.getValue())) {
+                    stateProbs[pomdpTransition.getColumn()] = pomdpTransition.getValue();
+                }
+            }
+            choices.push_back(stateProbs);
+        }
+    }
+    for (uint64_t obsId = 0; obsId < pomdp->getObservationValuations().getNumberOfStates(); ++obsId) {
+        auto obs = pomdp->getObservationValuations().getStateInfo(obsId);
+        std::replace( obs.begin(), obs.end(), '\t', ' ');
+        std::replace( obs.begin(), obs.end(), '\n', ' ');
+        observations.insert(obs);
+    }
+
+    os << "using QuickPOMDPs: QuickPOMDP \n" << "using POMDPTools: Deterministic, SparseCat\n\n"
+          << "pomdp = QuickPOMDP( \n"
+          << "   states = [";
+    for(uint64_t state = 0; state < pomdp->getNumberOfStates(); ++state){
+        os << "\"" << state << "\"";
+        if(state != pomdp->getNumberOfStates()-1){
+            os << ",";
+        }
+    }
+    os << "],\n";
+    std::string allActions;
+    for (auto const & action : actions){
+        allActions += "\"" + action + "\", ";
+    }
+    allActions.pop_back();
+    allActions.pop_back();
+    os << "   actions = function(s = nothing)\n"
+    << "      if isnothing(s)\n"
+    << "         return [" << allActions << "]\n"
+    << "      end\n";
+    for(uint64_t state = 0; state < pomdp->getNumberOfStates(); ++state) {
+        if (state == 0) {
+            os << "      if s == \"0\"\n";
+        } else if (state != pomdp->getNumberOfStates() - 1) {
+            os << "      elseif s == \"" << state << "\"\n";
+        } else {
+            os << "      else\n";
+        }
+        std::string actionStr;
+        for(auto const &entry : stateActionMap[state]){
+            actionStr += "\"" + entry + "\", ";
+        }
+        actionStr.pop_back();
+        actionStr.pop_back();
+        os << "         return [" << actionStr << "]\n";
+        if (state == pomdp->getNumberOfStates()-1){
+            os << "      end\n";
+        }
+    }
+    os << "   end,\n"
+
+       << "   observations = [";
+    uint64_t i = 0;
+    for(auto const &obs : observations){
+        os << "\"" << obs << "\"";
+        if(i != observations.size()-1){
+            os << ",";
+        }
+        ++i;
+    }
+    os << "],\n"
+    << "   discount = " << std::to_string(discount) << ",\n";
+
+    os << "   transition = function(s, a)\n";
+    for(uint64_t state = 0; state < pomdp->getNumberOfStates(); ++state){
+        auto rowIndex = pomdp->getTransitionMatrix().getRowGroupIndices()[state];
+        if(state == 0){
+            os << "      if s == \"0\"\n";
+        }
+        else if (state != pomdp->getNumberOfStates()-1){
+            os << "      elseif s == \"" << state << "\"\n";
+        } else {
+            os << "      else\n";
+        }
+        for (uint64_t action = 0; action < pomdp->getNumberOfChoices(state); ++action){
+            std::string label;
+            auto labelsOfChoice = pomdp->getChoiceLabeling().getLabelsOfChoice(rowIndex+action);
+            if(labelsOfChoice.empty()){
+                label = "__sink";
+            } else {
+                label = *(labelsOfChoice.begin());
+            }
+            std::replace( label.begin(), label.end(), '\t', ' ');
+            std::replace( label.begin(), label.end(), '\n', ' ');
+            if(action == 0) {
+                os << "         if a == \"" << label << "\"\n";
+            } else if (action != pomdp->getNumberOfChoices(state)-1){
+                os << "         elseif a == \"" << label << "\"\n";
+            } else {
+                os << "         else\n";
+            }
+            // Collect successors
+            std::string successorStateStr;
+            std::string successorProbStr;
+            for(auto const &entry : choices[rowIndex + action]){
+                successorStateStr += "\"" + std::to_string(entry.first) + "\", ";
+                successorProbStr += std::to_string(storm::utility::convertNumber<double>(entry.second)) + ", ";
+            }
+            successorStateStr.pop_back();
+            successorProbStr.pop_back();
+            successorStateStr.pop_back();
+            successorProbStr.pop_back();
+
+            os << "            return SparseCat([" << successorStateStr << "], [" << successorProbStr << "])\n";
+
+            if (action == pomdp->getNumberOfChoices(state)-1){
+                os << "         end\n";
+            }
+        }
+
+        if (state == pomdp->getNumberOfStates()-1){
+            os << "      end\n";
+        }
+    }
+    os << "   end,\n";
+
+    os << "   observation = function(a, sp)\n";
+    for(uint64_t state = 0; state < pomdp->getNumberOfStates(); ++state) {
+        if (state == 0) {
+            os << "      if sp == \"0\"\n";
+        } else if (state != pomdp->getNumberOfStates() - 1) {
+            os << "      elseif sp == \"" << state << "\"\n";
+        } else {
+            os << "      else\n";
+        }
+        auto obs = pomdp->getObservationValuations().getStateInfo(pomdp->getObservation(state));
+        std::replace( obs.begin(), obs.end(), '\t', ' ');
+        std::replace( obs.begin(), obs.end(), '\n', ' ');
+        os << "         return Deterministic(\"" << obs << "\")\n";
+        if (state == pomdp->getNumberOfStates()-1){
+            os << "      end\n";
+        }
+    }
+    os << "   end,\n";
+
+    os << "   reward = function(s, a, sp)\n";
+    i = 0;
+    if(probabilityAnalysis) {
+        // Generate a standard reward structure for probability analysis
+        // TODO Check if this need a sink to move to
+        for(auto const &target : targetStates){
+            if(i == 0){
+                os << "      if sp == \"" << target << "\"\n";
+            } else if (i != targetStates.getNumberOfSetBits()-1) {
+                os << "      elseif sp == \"" << target << "\"\n";
+            } else {
+                os << "      else\n";
+            }
+                os << "         return ";
+                if(min){
+                    os << "-";
+                }
+                  os << "1.0\n";
+            if (i == targetStates.getNumberOfSetBits()-1){
+                os << "      end\n";
+            }
+            ++i;
+        }
+    } else {
+        auto rewardModel = pomdp->getRewardModel(formulaInfo.getRewardModelName());
+        for(uint64_t state = 0; state < pomdp->getNumberOfStates(); ++state) {
+            if (state == 0) {
+                os << "      if s == \"0\"\n";
+            } else if (state != pomdp->getNumberOfStates() - 1) {
+                os << "      elseif s == \"" << state << "\"\n";
+            } else {
+                os << "      else\n";
+            }
+            if(rewardModel.hasOnlyStateRewards()){
+                os << "         return " << rewardModel.getStateReward(state) << "\n";
+            } else {
+                auto rowIndex = pomdp->getTransitionMatrix().getRowGroupIndices()[state];
+                for (uint64_t action = 0; action < pomdp->getNumberOfChoices(state); ++action){
+                    std::string label;
+                    auto labelsOfState = pomdp->getChoiceLabeling().getLabelsOfChoice(rowIndex+action);
+                    if(labelsOfState.empty()){
+                        label = "__sink";
+                    } else {
+                        label = *(labelsOfState.begin());
+                    }
+                    std::replace( label.begin(), label.end(), '\t', ' ');
+                    std::replace( label.begin(), label.end(), '\n', ' ');
+                    if(action == 0) {
+                        os << "         if a == \"" << label << "\"\n";
+                    } else if (action != pomdp->getNumberOfChoices(state)-1){
+                        os << "         elseif a == \"" << label << "\"\n";
+                    } else {
+                        os << "         else\n";
+                    }
+                    if(rewardModel.hasTransitionRewards()){
+                        //TODO iterate over all successors
+                        STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "Transition rewards are currently not supported by the transformation!");
+                    } else {
+                        os << "            return ";
+                        if(min){
+                            os << "-";
+                        }
+                        os << rewardModel.getStateActionReward(rowIndex + action) << "\n";
+                    }
+                    if (action == pomdp->getNumberOfChoices(state)-1){
+                        os << "         end\n";
+                    }
+                }
+            }
+            if (state == pomdp->getNumberOfStates() - 1) {
+                os << "      end\n";
+            }
+        }
+    }
+    os << "   end,\n";
+
+    os << "   initialstate = Deterministic(\"" << pomdp->getInitialStates().getNextSetIndex(0) << "\"),\n";
+    os << "   isterminal = s -> (" ;
+    i=0;
+    for(auto const &target : targetStates){
+        os << "s == \"" << target << "\"";
+        if (i != targetStates.getNumberOfSetBits()-1){
+            os << " || ";
+        }
+        ++i;
+    }
+    os << ")\n";
+    os << ")\n";
+}
+
+template void exportPomdpToJulia<double>(std::ostream& os, std::shared_ptr<storm::models::sparse::Pomdp<double>> pomdp, double discount, storm::logic::Formula const& formula);
+template void exportPomdpToJulia<storm::RationalNumber>(std::ostream& os, std::shared_ptr<storm::models::sparse::Pomdp<storm::RationalNumber>> pomdp, double discount, storm::logic::Formula const& formula);
+}
+}
+}

--- a/src/storm-pomdp/io/PomdpToJuliaExport.h
+++ b/src/storm-pomdp/io/PomdpToJuliaExport.h
@@ -1,0 +1,20 @@
+#include <iostream>
+
+#include "storm/logic/Formula.h"
+#include "storm/io/file.h"
+#include "storm/models/sparse/Pomdp.h"
+
+namespace storm {
+namespace pomdp {
+namespace exporter{
+
+
+/*!
+ * TODO
+ */
+template<typename ValueType>
+void exportPomdpToJulia(std::ostream& os, std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> pomdp, double discount, storm::logic::Formula const& formula);
+
+}
+}
+}

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -83,12 +83,12 @@ namespace storm {
             }
 
             template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>
-            void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::precomputeValueBounds(storm::logic::Formula const& formula) {
+            void BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::precomputeValueBounds(storm::logic::Formula const& formula, storm::solver::MinMaxMethod minMaxMethod) {
                 auto formulaInfo = storm::pomdp::analysis::getFormulaInformation(pomdp(), formula);
 
                 // Compute some initial bounds on the values for each state of the pomdp
                 // We work with the Belief MDP value type, so if the POMDP is exact, but the belief MDP is not, we need to convert
-                auto initialPomdpValueBounds = PreprocessingPomdpValueBoundsModelChecker<ValueType>(pomdp()).getValueBounds(formula, formulaInfo);
+                auto initialPomdpValueBounds = PreprocessingPomdpValueBoundsModelChecker<ValueType>(pomdp(), minMaxMethod).getValueBounds(formula, formulaInfo);
 
                 std::vector<ValueType> pMCValueBound;
                 if(options.useParametricPreprocessing && options.unfold){
@@ -100,7 +100,7 @@ namespace storm {
                 // If we clip and compute rewards, compute the values necessary for the correction terms
                 if((options.clippingThresholdInit > 0 || options.useGridClipping) && formula.isRewardOperatorFormula()){
                     pomdpValueBounds.extremePomdpValueBound =
-                        PreprocessingPomdpValueBoundsModelChecker<ValueType>(pomdp()).getExtremeValueBound(formula, formulaInfo);
+                        PreprocessingPomdpValueBoundsModelChecker<ValueType>(pomdp(), minMaxMethod).getExtremeValueBound(formula, formulaInfo);
                 }
             }
 
@@ -117,7 +117,7 @@ namespace storm {
                 // Extract the relevant information from the formula
                 auto formulaInfo = storm::pomdp::analysis::getFormulaInformation(pomdp(), formula);
                 
-                precomputeValueBounds(formula);
+                precomputeValueBounds(formula, options.preProcMinMaxMethod);
                 if(!additionalUnderApproximationBounds.empty()){
                     if(formulaInfo.minimize()){
                         pomdpValueBounds.trivialPomdpValueBounds.upper.insert(pomdpValueBounds.trivialPomdpValueBounds.upper.end(), std::make_move_iterator(additionalUnderApproximationBounds.begin()), std::make_move_iterator(additionalUnderApproximationBounds.end()));

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
@@ -50,7 +50,7 @@ namespace storm {
 
                 void printStatisticsToStream(std::ostream& stream) const;
 
-                void precomputeValueBounds(const logic::Formula& formula);
+                void precomputeValueBounds(const logic::Formula& formula, storm::solver::MinMaxMethod minMaxMethod = storm::solver::MinMaxMethod::SoundValueIteration);
                 
             private:
                 

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
@@ -114,6 +114,17 @@ namespace storm {
                 void clipToGrid(uint64_t clippingStateId, bool computeRewards, bool min, std::shared_ptr<BeliefManagerType> &beliefManager, std::shared_ptr<ExplorerType> &beliefExplorer);
 
                 /**
+                 * Clips the belief with the given state ID to a belief grid.
+                 * If a new candidate is added to the belief space, it is expanded. If necessary, its direct successors are added to the exploration queue to be handled by the main exploration routine.
+                 * @param clippingStateId the state ID of the clipping belief
+                 * @param computeRewards true, if rewards are computed
+                 * @param min true, if objective is to minimise
+                 * @param beliefManager the belief manager used
+                 * @param beliefExplorer the belief MDP explorer used
+                 */
+                void clipToGridExplicitly(uint64_t clippingStateId, bool computeRewards, bool min, std::shared_ptr<BeliefManagerType> &beliefManager, std::shared_ptr<ExplorerType> &beliefExplorer, uint64_t localActionIndex);
+
+                /**
                  * Clips the belief with the given state ID using already explored beliefs as candidates ("classic clipping")
                  * A clipping threshold can be given and a reduction of the candidate set to a given size using the belief difference 1-norm is applied if it is not disabled
                  * @param clippingStateId the state ID of the clipping belief

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerOptions.h
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerOptions.h
@@ -56,6 +56,8 @@ namespace storm {
 
                 storm::builder::ExplorationHeuristic explorationHeuristic = storm::builder::ExplorationHeuristic::BreadthFirst;
 
+                storm::solver::MinMaxMethod preProcMinMaxMethod = storm::solver::MinMaxMethod::SoundValueIteration;
+
             };
         }
     }

--- a/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.h
+++ b/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.h
@@ -73,7 +73,7 @@ namespace storm {
             public:
                 typedef PreprocessingPomdpValueBounds<ValueType> ValueBounds;
                 typedef ExtremePOMDPValueBound<ValueType> ExtremeValueBound;
-                PreprocessingPomdpValueBoundsModelChecker(storm::models::sparse::Pomdp<ValueType> const& pomdp);
+                PreprocessingPomdpValueBoundsModelChecker(storm::models::sparse::Pomdp<ValueType> const& pomdp, storm::solver::MinMaxMethod minMaxMethod = storm::solver::MinMaxMethod::SoundValueIteration);
                 
                 ValueBounds getValueBounds(storm::logic::Formula const& formula);
                 
@@ -83,6 +83,8 @@ namespace storm {
 
             private:
                 storm::models::sparse::Pomdp<ValueType> const& pomdp;
+
+                storm::Environment mcEnvironment;
 
                 std::vector<ValueType> getChoiceValues(std::vector<ValueType> const& stateValues, std::vector<ValueType>* actionBasedRewards);
 


### PR DESCRIPTION
This PR includes support for clipping in the export of POMDP policies in form of induced MC on the belief space.
In particular, it includes an extension of the clipping implementation that exposes all added transitions instead of eliminating intermediate states. This is triggered by the same flag as the explicit building of cut-off transitions, i.e. `--explicit-cutoff`.