### PR TITLE
Interface for observation-value-maps

### DIFF
--- a/resources/examples/testfiles/pomdp/simple2.prism
+++ b/resources/examples/testfiles/pomdp/simple2.prism
@@ -1,0 +1,24 @@
+pomdp
+
+observables
+    o
+endobservables
+
+module model
+    s : [0..2] init 0;
+    o : [0..1] init 0;
+    
+    [a] s=0 -> 0.9 : (s'=0) & (o'=0) + 0.1 : (s'=1) & (o'=0);
+    [a] s=1 -> 1 : true;
+    [a] s=2 -> 1 : true;
+    [b] s=0 -> 1 : (s'=2) & (o'=1);
+    [b] s=1 -> 1 : (s'=2) & (o'=1);
+
+endmodule
+
+rewards
+	[b] s=0 : 0;
+	[b] s=1 : 1;
+endrewards
+
+label "goal" = o=1;

--- a/src/storm-pomdp/api/verification.h
+++ b/src/storm-pomdp/api/verification.h
@@ -6,7 +6,7 @@ namespace api {
     template<typename ValueType>
     typename storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sparse::Pomdp<ValueType>>::Result
     underapproximateWithCutoffs(storm::Environment const& env, std::shared_ptr<storm::models::sparse::Pomdp<ValueType>> pomdp,
-                              storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& task, uint64_t sizeThreshold,  std::vector<std::vector<ValueType>> pomdpStateValues = std::vector<std::vector<ValueType>>()){
+                              storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> const& task, uint64_t sizeThreshold,  std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>> pomdpStateValues = std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>>()){
         storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType> options(false,true);
         options.useGridClipping = false;
         options.useExplicitCutoff = true;

--- a/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
+++ b/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
@@ -780,6 +780,16 @@ namespace storm {
         }
 
         template<typename PomdpType, typename BeliefValueType>
+        std::pair<bool, typename BeliefMdpExplorer<PomdpType, BeliefValueType>::ValueType>
+        BeliefMdpExplorer<PomdpType, BeliefValueType>::computeFMSchedulerValueForMemoryNode(BeliefId const &beliefId, uint64_t memoryNode) const {
+            STORM_LOG_ASSERT(!fmSchedulerValueList.empty(), "Requested finite memory scheduler value bounds but none were available.");
+            auto obs = beliefManager->getBeliefObservation(beliefId);
+            STORM_LOG_ASSERT(fmSchedulerValueList.size() > obs, "Requested value bound for observation " << obs << " not available.");
+            STORM_LOG_ASSERT(fmSchedulerValueList.at(obs).size() > memoryNode, "Requested value bound for observation " << obs << " and memory node " << memoryNode << " not available.");
+            return beliefManager->getWeightedSum(beliefId, fmSchedulerValueList.at(obs).at(memoryNode));
+        }
+
+        template<typename PomdpType, typename BeliefValueType>
         typename BeliefMdpExplorer<PomdpType, BeliefValueType>::ValueType
         BeliefMdpExplorer<PomdpType, BeliefValueType>::computeParametricBoundAtBelief(BeliefId const &beliefId) const {
             STORM_LOG_ASSERT(!pomdpValueBounds.parametric.empty(), "Parametric bounds not available.");
@@ -1171,6 +1181,16 @@ namespace storm {
         }
 
         template<typename PomdpType, typename BeliefValueType>
+        void BeliefMdpExplorer<PomdpType, BeliefValueType>::setFMSchedValueList(std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>> valueList){
+            fmSchedulerValueList = valueList;
+        }
+
+        template<typename PomdpType, typename BeliefValueType>
+        uint64_t BeliefMdpExplorer<PomdpType, BeliefValueType>::getNrOfMemoryNodesForObservation(uint32_t observation) const{
+            return fmSchedulerValueList.at(observation).size();
+        }
+
+        template<typename PomdpType, typename BeliefValueType>
         typename BeliefMdpExplorer<PomdpType, BeliefValueType>::ValueType BeliefMdpExplorer<PomdpType, BeliefValueType>::getExtremeValueBoundAtPOMDPState(const uint64_t &pomdpState){
             return extremeValueBound.getValueForState(pomdpState);
         }
@@ -1218,6 +1238,11 @@ namespace storm {
         BeliefMdpExplorer<PomdpType, BeliefValueType>::getUpperValueBoundSchedulers() const {
             STORM_LOG_ASSERT(!pomdpValueBounds.upperSchedulers.empty(), "Requested upper bound schedulers but none were available.");
             return pomdpValueBounds.upperSchedulers;
+        }
+
+        template<typename PomdpType, typename BeliefValueType>
+        bool BeliefMdpExplorer<PomdpType, BeliefValueType>::hasFMSchedulerValues() const {
+            return !fmSchedulerValueList.empty();
         }
 
         template

--- a/src/storm-pomdp/builder/BeliefMdpExplorer.h
+++ b/src/storm-pomdp/builder/BeliefMdpExplorer.h
@@ -167,6 +167,8 @@ namespace storm {
 
             ValueType computeUpperValueBoundForScheduler(BeliefId const &beliefId, uint64_t schedulerId) const;
 
+            std::pair<bool, ValueType> computeFMSchedulerValueForMemoryNode(BeliefId const &beliefId, uint64_t memoryNode) const;
+
             storm::storage::Scheduler<ValueType> getUpperValueBoundScheduler(uint64_t schedulerId) const;
 
             storm::storage::Scheduler<ValueType> getLowerValueBoundScheduler(uint64_t schedulerId) const;
@@ -180,6 +182,8 @@ namespace storm {
             void computeValuesOfExploredMdp(storm::solver::OptimizationDirection const &dir);
 
             bool hasComputedValues() const;
+
+            bool hasFMSchedulerValues() const;
 
             std::vector<ValueType> const &getValuesOfExploredMdp() const;
 
@@ -240,6 +244,10 @@ namespace storm {
 
             const std::shared_ptr<storm::storage::Scheduler<BeliefMdpExplorer<PomdpType, BeliefValueType>::ValueType>> &getSchedulerForExploredMdp() const;
 
+            void setFMSchedValueList(std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>> valueList);
+
+            uint64_t getNrOfMemoryNodesForObservation(uint32_t observation) const;
+
         private:
             MdpStateType noState() const;
 
@@ -295,6 +303,7 @@ namespace storm {
             // Value and scheduler related information
             storm::pomdp::modelchecker::PreprocessingPomdpValueBounds<ValueType> pomdpValueBounds;
             storm::pomdp::modelchecker::ExtremePOMDPValueBound<ValueType> extremeValueBound;
+            std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>> fmSchedulerValueList;
             std::vector<ValueType> lowerValueBounds;
             std::vector<ValueType> upperValueBounds;
             std::vector<ValueType> values; // Contains an estimate during building and the actual result after a check has performed

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -618,6 +618,58 @@ namespace storm {
                         result.cutoffSchedulers = underApproximation->getLowerValueBoundSchedulers();
                     }
                 }
+
+                if (underApproximation->hasComputedValues()) {
+                    std::shared_ptr<storm::models::sparse::Model<ValueType>> scheduledModel = underApproximation->getExploredMdp();
+                    std::vector<uint32_t> observations = underApproximation->getObservationForMdpStates();
+                    storm::models::sparse::StateLabeling newLabeling(scheduledModel->getStateLabeling());
+                    auto nrPreprocessingScheds = min ? underApproximation->getNrSchedulersForUpperBounds() : underApproximation->getNrSchedulersForLowerBounds();
+                    for(uint64_t i = 0; i < nrPreprocessingScheds; ++i){
+                        newLabeling.addLabel("sched_" + std::to_string(i));
+                    }
+                    newLabeling.addLabel("cutoff");
+                    newLabeling.addLabel("clipping");
+
+                    auto transMatrix = scheduledModel->getTransitionMatrix();
+                    for(uint64_t i = 0; i < scheduledModel->getNumberOfStates(); ++i){
+                        if(newLabeling.getStateHasLabel("truncated",i)){
+                            bool hasClipping = (underApproximation->getExploredMdp()->getNumberOfChoices(i) != nrPreprocessingScheds);
+                            uint64_t chosenActionIndex = underApproximation->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice();
+                            if(hasClipping){
+                                if(chosenActionIndex == 0){
+                                    newLabeling.addLabelToState("clipping", i);
+                                    auto chosenRow = transMatrix.getRow(i,0);
+                                    auto candidateIndex = (chosenRow.end() - 1)->getColumn();
+                                    transMatrix.makeRowDirac(transMatrix.getRowGroupIndices()[i], candidateIndex);
+                                } else {
+                                    newLabeling.addLabelToState(
+                                        "sched_" + std::to_string(underApproximation->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice() - 1), i);
+                                    newLabeling.addLabelToState("cutoff", i);
+                                }
+                            } else {
+                                newLabeling.addLabelToState(
+                                    "sched_" + std::to_string(underApproximation->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice()), i);
+                                newLabeling.addLabelToState("cutoff", i);
+                            }
+                        }
+                    }
+                    newLabeling.removeLabel("truncated");
+
+                    transMatrix.dropZeroEntries();
+                    storm::storage::sparse::ModelComponents<ValueType> modelComponents(transMatrix, newLabeling);
+                    if(scheduledModel->hasChoiceLabeling()){
+                        modelComponents.choiceLabeling = scheduledModel->getChoiceLabeling();
+                    }
+                    storm::models::sparse::Mdp<ValueType> newMDP(modelComponents);
+                    auto inducedMC = newMDP.applyScheduler(*(underApproximation->getSchedulerForExploredMdp()), true);
+                    scheduledModel = std::static_pointer_cast<storm::models::sparse::Model<ValueType>>(inducedMC);
+                    result.schedulerAsMarkovChain = scheduledModel;
+                    if(min){
+                        result.cutoffSchedulers = underApproximation->getUpperValueBoundSchedulers();
+                    } else {
+                        result.cutoffSchedulers = underApproximation->getLowerValueBoundSchedulers();
+                    }
+                }
             }
 
             template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -105,7 +105,7 @@ namespace storm {
             }
 
             template<typename PomdpModelType, typename BeliefValueType, typename BeliefMDPType>
-            typename BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::Result BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::check(storm::logic::Formula const& formula, std::vector<std::vector<ValueType>> additionalUnderApproximationBounds) {
+            typename BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::Result BeliefExplorationPomdpModelChecker<PomdpModelType, BeliefValueType, BeliefMDPType>::check(storm::logic::Formula const& formula, std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>> const& additionalUnderApproximationBounds) {
                 STORM_LOG_ASSERT(options.unfold || options.discretize, "Invoked belief exploration but no task (unfold or discretize) given.");
                 
                 // Potentially reset preprocessed model from previous call
@@ -119,11 +119,7 @@ namespace storm {
                 
                 precomputeValueBounds(formula, options.preProcMinMaxMethod);
                 if(!additionalUnderApproximationBounds.empty()){
-                    if(formulaInfo.minimize()){
-                        pomdpValueBounds.trivialPomdpValueBounds.upper.insert(pomdpValueBounds.trivialPomdpValueBounds.upper.end(), std::make_move_iterator(additionalUnderApproximationBounds.begin()), std::make_move_iterator(additionalUnderApproximationBounds.end()));
-                    } else {
-                        pomdpValueBounds.trivialPomdpValueBounds.lower.insert(pomdpValueBounds.trivialPomdpValueBounds.lower.end(), std::make_move_iterator(additionalUnderApproximationBounds.begin()), std::make_move_iterator(additionalUnderApproximationBounds.end()));
-                    }
+                        pomdpValueBounds.fmSchedulerValueList = additionalUnderApproximationBounds;
                 }
                 uint64_t initialPomdpState = pomdp().getInitialStates().getNextSetIndex(0);
                 Result result(pomdpValueBounds.trivialPomdpValueBounds.getHighestLowerBound(initialPomdpState), pomdpValueBounds.trivialPomdpValueBounds.getSmallestUpperBound(initialPomdpState));
@@ -324,6 +320,9 @@ namespace storm {
                     if((options.clippingThresholdInit > 0 || options.useGridClipping) && rewardModelName.is_initialized()) {
                         approx->setExtremeValueBound(valueBounds.extremePomdpValueBound);
                     }
+                    if(!valueBounds.fmSchedulerValueList.empty()){
+                        approx->setFMSchedValueList(valueBounds.fmSchedulerValueList);
+                    }
                     buildUnderApproximation(targetObservations, min, rewardModelName.is_initialized(), false, heuristicParameters, manager, approx);
                     if (approx->hasComputedValues()) {
                         auto printInfo = [&approx]() {
@@ -338,6 +337,9 @@ namespace storm {
                         auto nrPreprocessingScheds = min ? approx->getNrSchedulersForUpperBounds() : approx->getNrSchedulersForLowerBounds();
                         for(uint64_t i = 0; i < nrPreprocessingScheds; ++i){
                             newLabeling.addLabel("sched_" + std::to_string(i));
+                        }
+                        if(approx->hasFMSchedulerValues()){
+                            newLabeling.addLabel("finite_mem");
                         }
                         newLabeling.addLabel("cutoff");
                         newLabeling.addLabel("clipping");
@@ -354,13 +356,21 @@ namespace storm {
                                         auto candidateIndex = (chosenRow.end() - 1)->getColumn();
                                         transMatrix.makeRowDirac(transMatrix.getRowGroupIndices()[i], candidateIndex);
                                     } else {
-                                        newLabeling.addLabelToState(
-                                            "sched_" + std::to_string(approx->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice() - 1), i);
+                                        if(!approx->hasFMSchedulerValues() || approx->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice() - 1 < nrPreprocessingScheds) {
+                                            newLabeling.addLabelToState(
+                                                "sched_" + std::to_string(approx->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice() - 1), i);
+                                        } else {
+                                            newLabeling.addLabelToState("finite_mem", i);
+                                        }
                                         newLabeling.addLabelToState("cutoff", i);
                                     }
                                 } else {
-                                    newLabeling.addLabelToState(
-                                        "sched_" + std::to_string(approx->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice()), i);
+                                    if(!approx->hasFMSchedulerValues() || approx->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice() < nrPreprocessingScheds) {
+                                        newLabeling.addLabelToState(
+                                            "sched_" + std::to_string(approx->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice()), i);
+                                    } else {
+                                        newLabeling.addLabelToState("finite_mem", i);
+                                    }
                                     newLabeling.addLabelToState("cutoff", i);
                                 }
                             }
@@ -548,6 +558,64 @@ namespace storm {
                         STORM_LOG_INFO("Refinement fixpoint reached after " << statistics.refinementSteps.get() << " iterations.\n");
                         statistics.refinementFixpointDetected = true;
                         break;
+                    }
+                }
+                if (underApproximation->hasComputedValues()) {
+                    std::shared_ptr<storm::models::sparse::Model<ValueType>> scheduledModel = underApproximation->getExploredMdp();
+                    storm::models::sparse::StateLabeling newLabeling(scheduledModel->getStateLabeling());
+                    auto nrPreprocessingScheds = min ? underApproximation->getNrSchedulersForUpperBounds() : underApproximation->getNrSchedulersForLowerBounds();
+                    for(uint64_t i = 0; i < nrPreprocessingScheds; ++i){
+                        newLabeling.addLabel("sched_" + std::to_string(i));
+                    }
+                    newLabeling.addLabel("cutoff");
+                    newLabeling.addLabel("clipping");
+
+                    auto transMatrix = scheduledModel->getTransitionMatrix();
+                    for(uint64_t i = 0; i < scheduledModel->getNumberOfStates(); ++i){
+                        if(newLabeling.getStateHasLabel("truncated",i)){
+                            bool hasClipping = (underApproximation->getExploredMdp()->getNumberOfChoices(i) != nrPreprocessingScheds);
+                            uint64_t chosenActionIndex = underApproximation->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice();
+                            if(hasClipping){
+                                if(chosenActionIndex == 0){
+                                    newLabeling.addLabelToState("clipping", i);
+                                    auto chosenRow = transMatrix.getRow(i,0);
+                                    auto candidateIndex = (chosenRow.end() - 1)->getColumn();
+                                    transMatrix.makeRowDirac(transMatrix.getRowGroupIndices()[i], candidateIndex);
+                                } else {
+                                    if(!underApproximation->hasFMSchedulerValues() || underApproximation->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice() - 1 < nrPreprocessingScheds) {
+                                        newLabeling.addLabelToState(
+                                            "sched_" + std::to_string(underApproximation->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice() - 1), i);
+                                    } else {
+                                        newLabeling.addLabelToState("finite_mem", i);
+                                    }
+                                    newLabeling.addLabelToState("cutoff", i);
+                                }
+                            } else {
+                                if(!underApproximation->hasFMSchedulerValues() || underApproximation->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice() < nrPreprocessingScheds) {
+                                    newLabeling.addLabelToState(
+                                        "sched_" + std::to_string(underApproximation->getSchedulerForExploredMdp()->getChoice(i).getDeterministicChoice()), i);
+                                } else {
+                                    newLabeling.addLabelToState("finite_mem", i);
+                                }
+                                newLabeling.addLabelToState("cutoff", i);
+                            }
+                        }
+                    }
+                    newLabeling.removeLabel("truncated");
+
+                    transMatrix.dropZeroEntries();
+                    storm::storage::sparse::ModelComponents<ValueType> modelComponents(transMatrix, newLabeling);
+                    if(scheduledModel->hasChoiceLabeling()){
+                        modelComponents.choiceLabeling = scheduledModel->getChoiceLabeling();
+                    }
+                    storm::models::sparse::Mdp<ValueType> newMDP(modelComponents);
+                    auto inducedMC = newMDP.applyScheduler(*(underApproximation->getSchedulerForExploredMdp()), true);
+                    scheduledModel = std::static_pointer_cast<storm::models::sparse::Model<ValueType>>(inducedMC);
+                    result.schedulerAsMarkovChain = scheduledModel;
+                    if(min){
+                        result.cutoffSchedulers = underApproximation->getUpperValueBoundSchedulers();
+                    } else {
+                        result.cutoffSchedulers = underApproximation->getLowerValueBoundSchedulers();
                     }
                 }
             }
@@ -1041,6 +1109,32 @@ namespace storm {
                                 }
                                 if (pomdp().hasChoiceLabeling()) {
                                     underApproximation->addChoiceLabelToCurrentState(addedActions + i, "sched_" + std::to_string(i));
+                                }
+                            }
+                            addedActions += nrCutoffStrategies;
+                            if (underApproximation->hasFMSchedulerValues()) {
+                                uint64_t transitionNr = 0;
+                                for (uint64_t i = 0; i < underApproximation->getNrOfMemoryNodesForObservation(currObservation); ++i) {
+                                    auto resPair = underApproximation->computeFMSchedulerValueForMemoryNode(currId, i);
+                                    ValueType cutOffValue;
+                                    if (resPair.first) {
+                                        cutOffValue = resPair.second;
+                                    } else {
+                                        STORM_LOG_DEBUG("Skipped cut-off of belief with ID " << currId << " with finite memory scheduler in memory node " << i
+                                                                                             << ". Missing values.");
+                                        continue;
+                                    }
+                                    if (computeRewards) {
+                                        underApproximation->addTransitionsToExtraStates(addedActions + transitionNr, storm::utility::one<ValueType>());
+                                        underApproximation->addRewardToCurrentState(addedActions + transitionNr, cutOffValue);
+                                    } else {
+                                        underApproximation->addTransitionsToExtraStates(addedActions + transitionNr, cutOffValue,
+                                                                                        storm::utility::one<ValueType>() - cutOffValue);
+                                    }
+                                    if (pomdp().hasChoiceLabeling()) {
+                                        underApproximation->addChoiceLabelToCurrentState(addedActions + transitionNr, "mem_node_" + std::to_string(i));
+                                    }
+                                    ++transitionNr;
                                 }
                             }
                         }

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -621,7 +621,6 @@ namespace storm {
 
                 if (underApproximation->hasComputedValues()) {
                     std::shared_ptr<storm::models::sparse::Model<ValueType>> scheduledModel = underApproximation->getExploredMdp();
-                    std::vector<uint32_t> observations = underApproximation->getObservationForMdpStates();
                     storm::models::sparse::StateLabeling newLabeling(scheduledModel->getStateLabeling());
                     auto nrPreprocessingScheds = min ? underApproximation->getNrSchedulersForUpperBounds() : underApproximation->getNrSchedulersForLowerBounds();
                     for(uint64_t i = 0; i < nrPreprocessingScheds; ++i){

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h
@@ -22,6 +22,7 @@ namespace storm {
             struct POMDPValueBounds{
                 storm::pomdp::modelchecker::PreprocessingPomdpValueBounds<ValueType> trivialPomdpValueBounds;
                 storm::pomdp::modelchecker::ExtremePOMDPValueBound<ValueType> extremePomdpValueBound;
+                std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>> fmSchedulerValueList;
             };
             
             template<typename PomdpModelType, typename BeliefValueType = typename PomdpModelType::ValueType, typename BeliefMDPType = typename PomdpModelType::ValueType>
@@ -46,7 +47,7 @@ namespace storm {
                 
                 BeliefExplorationPomdpModelChecker(std::shared_ptr<PomdpModelType> pomdp, Options options = Options());
                 
-                Result check(storm::logic::Formula const& formula, std::vector<std::vector<ValueType>> additionalUnderApproximationBounds = std::vector<std::vector<ValueType>>());
+                Result check(storm::logic::Formula const& formula, std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>> const& additionalUnderApproximationBounds = std::vector<std::vector<std::unordered_map<uint64_t,ValueType>>>());
 
                 void printStatisticsToStream(std::ostream& stream) const;
 

--- a/src/storm-pomdp/storage/BeliefManager.cpp
+++ b/src/storm-pomdp/storage/BeliefManager.cpp
@@ -136,6 +136,23 @@ namespace storm {
         }
 
         template<typename PomdpType, typename BeliefValueType, typename StateType>
+        std::pair<bool, typename BeliefManager<PomdpType, BeliefValueType, StateType>::ValueType>
+        BeliefManager<PomdpType, BeliefValueType, StateType>::getWeightedSum(BeliefId const &beliefId, std::unordered_map<StateType, ValueType> const& summands) {
+            bool successful = true;
+            auto result = storm::utility::zero<ValueType>();
+            for (auto const &entry : getBelief(beliefId)) {
+                auto probIter = summands.find(entry.first);
+                if (probIter != summands.end()){
+                    result += storm::utility::convertNumber<ValueType>(entry.second) * storm::utility::convertNumber<ValueType>(summands.at(entry.first));
+                } else {
+                    successful = false;
+                    break;
+                }
+            }
+            return {successful, result};
+        }
+
+        template<typename PomdpType, typename BeliefValueType, typename StateType>
         typename BeliefManager<PomdpType, BeliefValueType, StateType>::BeliefId const &BeliefManager<PomdpType, BeliefValueType, StateType>::getInitialBelief() const {
             return initialBeliefId;
         }

--- a/src/storm-pomdp/storage/BeliefManager.h
+++ b/src/storm-pomdp/storage/BeliefManager.h
@@ -60,6 +60,8 @@ namespace storm {
 
             ValueType getWeightedSum(BeliefId const &beliefId, std::vector<ValueType> const &summands);
 
+            std::pair<bool, ValueType> getWeightedSum(BeliefId const &beliefId, std::unordered_map<StateType, ValueType> const &summands);
+
             BeliefId const &getInitialBelief() const;
 
             ValueType getBeliefActionReward(BeliefId const &beliefId, uint64_t const &localActionIndex) const;

--- a/src/test/storm-pomdp/api/BeliefExplorationAPITest.cpp
+++ b/src/test/storm-pomdp/api/BeliefExplorationAPITest.cpp
@@ -183,10 +183,10 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmax) {
     ValueType expected = this->parseNumber("29/30");
     EXPECT_LE(result.lowerBound, expected + this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(5, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result,0));
-    EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result,1), std::out_of_range);
+    EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result,5), std::out_of_range);
 }
 
 TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmin) {
@@ -199,10 +199,10 @@ TYPED_TEST(BeliefExplorationAPITest, simple_slippery_Rmin) {
     ValueType expected = this->parseNumber("19/30");
     EXPECT_GE(result.upperBound, expected - this->modelcheckingPrecision());
 
-    EXPECT_EQ(1, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
+    EXPECT_EQ(5, storm::pomdp::api::getNumberOfPreprocessingSchedulers<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::extractSchedulerAsMarkovChain<ValueType>(result));
     EXPECT_NO_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result,0));
-    EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result,1), std::out_of_range);
+    EXPECT_THROW(storm::pomdp::api::getCutoffScheduler<ValueType>(result,5), std::out_of_range);
 }
 
 TYPED_TEST(BeliefExplorationAPITest, maze2_Rmin) {


### PR DESCRIPTION
This PR contains the implementation of the interface for representations of finite memory policies by observation-value-maps provided by PAYNT.
The `check()` function of the BeliefExplorationModelChecker takes as an additional argument a vector of vectors of maps between states and values, i.e. vector(observation)->vector(memory node)->map(state->value). The values provided by this data structure are used in the cut-off approach to approximate beleif values. In particular, for each available memory node, a separate cut-off transition is generated.

