### PR TITLE
Removed line using old deleted function

### DIFF
--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -333,7 +333,6 @@ namespace storm {
                         };
 
                         std::shared_ptr<storm::models::sparse::Model<ValueType>> scheduledModel = approx->getExploredMdp();
-                        std::vector<uint32_t> observations = approx->getObservationForMdpStates();
                         storm::models::sparse::StateLabeling newLabeling(scheduledModel->getStateLabeling());
                         auto nrPreprocessingScheds = min ? approx->getNrSchedulersForUpperBounds() : approx->getNrSchedulersForLowerBounds();
                         for(uint64_t i = 0; i < nrPreprocessingScheds; ++i){

--- a/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.cpp
@@ -379,24 +379,6 @@ namespace storm {
 
                         transMatrix.dropZeroEntries();
                         storm::storage::sparse::ModelComponents<ValueType> modelComponents(transMatrix, newLabeling);
-                        
-                        /*
-                        // randriu: resolving conflict
-                        // TODO replace labels by exporting a map
-                        for(uint64_t i = 0; i < pomdp().getNrObservations(); ++i){
-                            newLabeling.addLabel("obs_" + std::to_string(i));
-                        }
-                        newLabeling.addLabel("no_obs");
-                        for(uint64_t i = 0; i < scheduledModel->getNumberOfStates(); ++i){
-                            if (observations[i] <= pomdp().getNrObservations()) {
-                                newLabeling.addLabelToState("obs_" + std::to_string(observations[i]), i);
-                            } else {
-                                newLabeling.addLabelToState("no_obs", i);
-                            }
-                        }
-
-                        storm::storage::sparse::ModelComponents<ValueType> modelComponents(scheduledModel->getTransitionMatrix(), newLabeling, scheduledModel->getRewardModels());
-                        */
 
                         if(scheduledModel->hasChoiceLabeling()){
                             modelComponents.choiceLabeling = scheduledModel->getChoiceLabeling();


### PR DESCRIPTION
In the last MR by Alex he removed a function for getting observation indices that Sebastian created as a quick fix some months ago, so I removed the line where it is still used. 

It probably showed up there again as a result of those merge conflicts.